### PR TITLE
Implement POST /soulseed endpoint

### DIFF
--- a/tests/backend/main.py
+++ b/tests/backend/main.py
@@ -1,16 +1,18 @@
-"""
-Sprint-5 placeholder for the SoulSeed FastAPI app.
+"""SoulSeed FastAPI backend used by the test-suite.
 
-— What the tests expect —
-1. The file must import / create a FastAPI instance called `app`.
-2. It must register a GET route at `/soulseed`.
-3. It must expose an `import_main()` helper that simply returns `app`.
-
-When you’re ready to flesh things out, replace the stub logic
-inside `soulseed_root()` and add additional routes as usual.
+Originally this was only a small stub exposing a health-check route at
+``/soulseed``.  For the current sprint the file houses a minimal
+implementation of the ``POST /soulseed`` endpoint that creates a player
+profile.  The older health-check route remains for backwards
+compatibility so existing tests continue to pass.
 """
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, constr
+from pathlib import Path
+import hashlib
+import json
+import re
 
 #: minimal FastAPI app the tests look for
 app = FastAPI(title="SoulSeed API stub")
@@ -20,6 +22,67 @@ app = FastAPI(title="SoulSeed API stub")
 def soulseed_root() -> dict[str, str]:
     """Health-check endpoint required by the placeholder test suite."""
     return {"status": "alive"}
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+DATA_FILE = Path(__file__).resolve().parents[2] / "backend" / "player_profile.json"
+
+
+def load_profiles() -> dict:
+    if DATA_FILE.exists():
+        try:
+            with open(DATA_FILE, "r", encoding="utf-8") as f:
+                return json.load(f) or {}
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def save_profiles(data: dict) -> None:
+    DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(DATA_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    slug = re.sub(r"-+", "-", slug)
+    return slug
+
+
+class SoulSeedRequest(BaseModel):
+    playerName: constr(min_length=1)
+    archetype: constr(min_length=1)
+
+
+class SoulSeedResponse(BaseModel):
+    playerId: str
+    soulSeedId: str
+    initSceneTag: str
+
+
+@app.post("/soulseed", response_model=SoulSeedResponse)
+def create_soulseed(request: SoulSeedRequest) -> SoulSeedResponse:
+    player_id = slugify(request.playerName)
+    seed_source = f"{request.playerName}|{request.archetype}"
+    soul_seed_id = hashlib.sha256(seed_source.encode()).hexdigest()[:12]
+
+    profiles = load_profiles()
+    profiles[player_id] = {
+        "playerName": request.playerName,
+        "archetype": request.archetype,
+        "soulSeedId": soul_seed_id,
+    }
+    save_profiles(profiles)
+
+    return SoulSeedResponse(
+        playerId=player_id,
+        soulSeedId=soul_seed_id,
+        initSceneTag="intro_001",
+    )
 
 
 def import_main():

--- a/tests/backend/test_soulseed.py
+++ b/tests/backend/test_soulseed.py
@@ -1,0 +1,45 @@
+import json
+import importlib.util
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+BACKEND_DIR = Path(__file__).parent
+BACKEND = BACKEND_DIR / "main.py"
+PROFILE_FILE = Path(__file__).resolve().parents[2] / "backend" / "player_profile.json"
+
+
+def import_app():
+    spec = importlib.util.spec_from_file_location("main", BACKEND)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.app
+
+
+def setup_function(_):
+    PROFILE_FILE.write_text("{}", encoding="utf-8")
+
+
+def test_create_soulseed():
+    client = TestClient(import_app())
+
+    payload = {"playerName": "Alice Smith", "archetype": "wizard"}
+    resp = client.post("/soulseed", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["playerId"] == "alice-smith"
+    assert data["initSceneTag"] == "intro_001"
+    assert isinstance(data["soulSeedId"], str) and len(data["soulSeedId"]) == 12
+
+    resp2 = client.post("/soulseed", json=payload)
+    assert resp2.status_code == 200
+    assert resp2.json()["soulSeedId"] == data["soulSeedId"]
+
+    profiles = json.loads(PROFILE_FILE.read_text())
+    assert data["playerId"] in profiles
+    assert profiles[data["playerId"]]["soulSeedId"] == data["soulSeedId"]
+
+
+def test_validation_error():
+    client = TestClient(import_app())
+    resp = client.post("/soulseed", json={"playerName": "", "archetype": "mage"})
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- expand backend FastAPI stub into a real player profile endpoint
- persist player profiles in `backend/player_profile.json`
- create tests covering soulseed creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685075a93d4c832bb398b0f8a15f38bd