### PR TITLE
Implement TrustManager persistence and tests

### DIFF
--- a/backend/trust.py
+++ b/backend/trust.py
@@ -1,8 +1,56 @@
 # backend/trust.py
-"""
-Sprint 7 placeholder.  Will house TrustManager class & helpers.
-The tests only assert that this file exists.
-"""
+"""Simple persistent trust tracker for players."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
 class TrustManager:
-    def __init__(self):
-        self.trust = 0
+    """Manage a player's trust score persisted in a JSON file."""
+
+    def __init__(self, player_name: str, path: str = "backend/player_state.json"):
+        self.player_name = player_name
+        self.path = Path(path)
+        self.trust: float = 0.0
+        self.load()
+
+    # persistence -----------------------------------------------------
+    def load(self) -> None:
+        """Load trust value from ``self.path`` for ``self.player_name``."""
+        try:
+            with self.path.open("r") as fh:
+                data = json.load(fh)
+        except FileNotFoundError:
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+        self.trust = float(data.get(self.player_name, 0))
+
+    def save(self) -> None:
+        """Save current trust value to ``self.path``."""
+        try:
+            with self.path.open("r") as fh:
+                data = json.load(fh)
+        except FileNotFoundError:
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+        data[self.player_name] = self.trust
+        with self.path.open("w") as fh:
+            json.dump(data, fh, indent=2)
+
+    # api -------------------------------------------------------------
+    def adjust(self, delta: float) -> None:
+        """Change trust by ``delta``, clamp to [-100, 100], then save."""
+        self.trust += float(delta)
+        if self.trust > 100:
+            self.trust = 100
+        elif self.trust < -100:
+            self.trust = -100
+        self.save()
+
+    def get(self) -> float:
+        """Return the current trust score."""
+        return self.trust

--- a/tests/backend/test_trust.py
+++ b/tests/backend/test_trust.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import importlib.util
+
+ROOT = Path(__file__).parents[2]
+TRUST_PATH = ROOT / "backend" / "trust.py"
+
+spec = importlib.util.spec_from_file_location("trust", TRUST_PATH)
+trust_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(trust_module)
+TrustManager = trust_module.TrustManager
+
+
+def test_adjust_increase(tmp_path):
+    path = tmp_path / "state.json"
+    tm = TrustManager("alice", path=str(path))
+    before = tm.get()
+    tm.adjust(5)
+    tm_reloaded = TrustManager("alice", path=str(path))
+    assert tm_reloaded.get() == before + 5
+
+
+def test_adjust_decrease(tmp_path):
+    path = tmp_path / "state.json"
+    tm = TrustManager("bob", path=str(path))
+    tm.adjust(5)
+    tm2 = TrustManager("bob", path=str(path))
+    tm2.adjust(-3)
+    tm3 = TrustManager("bob", path=str(path))
+    assert tm3.get() == 2


### PR DESCRIPTION
## Summary
- flesh out `TrustManager` with persistence and clamping
- add tests verifying adjust/load behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685075bd73c0832bb131a78aa0f8f80c