### PR TITLE
Add story engine and scene view

### DIFF
--- a/backend/story.json
+++ b/backend/story.json
@@ -1,42 +1,38 @@
 {
-    "start": {
-      "text": "You are standing at a crossroad. Where do you want to go?",
-      "choices": {
-        "1": "dark_forest",
-        "2": "sunny_meadow"
-      }
-    },
-    "dark_forest": {
-      "text": "You walk into the dark forest and feel the trees close around you. You hear a strange noise.",
-      "choices": {
-        "1": "investigate_noise",
-        "2": "run_away"
-      }
-    },
-    "sunny_meadow": {
-      "text": "You head into the sunny meadow, the warm sun on your skin. You see a river sparkling in the distance.",
-      "choices": {
-        "1": "go_to_river",
-        "2": "lie_down"
-      }
-    },
-    "investigate_noise": {
-      "text": "You move toward the noise and discover a hidden treasure chest! The End."
-    },
-    "run_away": {
-      "text": "You run away safely but always wonder what you missed. The End."
-    },
-    "go_to_river": {
-      "text": "You sit by the river and find peace in the sound of water. The End."
-    },
-    "lie_down": {
-      "text": "You lie down in the meadow and fall into a deep, restful sleep. The End."
-    },
-    "lie_down": {
-      "text": "You lie down in the meadow and fall into a deep, restful sleep. The End."
-    },
-    "secret_cave": {
-      "text": "You discover a hidden cave glittering with ancient crystals. The air hums with power!"
+  "intro_001": {
+    "text": "You are standing at a crossroad. Where do you want to go?",
+    "choices": {
+      "1": "dark_forest",
+      "2": "sunny_meadow"
     }
+  },
+  "dark_forest": {
+    "text": "You walk into the dark forest and feel the trees close around you. You hear a strange noise.",
+    "choices": {
+      "1": "investigate_noise",
+      "2": "run_away"
+    }
+  },
+  "sunny_meadow": {
+    "text": "You head into the sunny meadow, the warm sun on your skin. You see a river sparkling in the distance.",
+    "choices": {
+      "1": "go_to_river",
+      "2": "lie_down"
+    }
+  },
+  "investigate_noise": {
+    "text": "You move toward the noise and discover a hidden treasure chest! The End."
+  },
+  "run_away": {
+    "text": "You run away safely but always wonder what you missed. The End."
+  },
+  "go_to_river": {
+    "text": "You sit by the river and find peace in the sound of water. The End."
+  },
+  "lie_down": {
+    "text": "You lie down in the meadow and fall into a deep, restful sleep. The End."
+  },
+  "secret_cave": {
+    "text": "You discover a hidden cave glittering with ancient crystals. The air hums with power!"
   }
-  
+}

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import Liminal from './scenes/Liminal';
 import AvatarCreate from './scenes/AvatarCreate';
+import SceneView from './scenes/SceneView';
 
 export default function App() {
   return (
@@ -9,6 +10,7 @@ export default function App() {
         <Route path="/" element={<Navigate to="/liminal" replace />} />
         <Route path="/liminal" element={<Liminal />} />
         <Route path="/avatar" element={<AvatarCreate />} />
+        <Route path="/scene" element={<SceneView />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/scenes/SceneView.tsx
+++ b/frontend/src/scenes/SceneView.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+type Choice = { tag: string; label: string };
+type Scene = { sceneTag: string; text: string; choices: Choice[] };
+
+export default function SceneView() {
+  const [scene, setScene] = useState<Scene | null>(null);
+  const soulSeedId = 'demo';
+
+  useEffect(() => {
+    fetch('/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ soulSeedId }),
+    })
+      .then((r) => r.json())
+      .then(setScene)
+      .catch(() => {});
+  }, []);
+
+  const handleChoice = (choiceTag: string) => {
+    if (!scene) return;
+    fetch('/choice', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ soulSeedId, sceneTag: scene.sceneTag, choiceTag }),
+    })
+      .then((r) => r.json())
+      .then(setScene)
+      .catch(() => {});
+  };
+
+  if (!scene) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div style={{ padding: 24, fontFamily: 'sans-serif' }}>
+      <div style={{ background: '#eee', padding: 12, borderRadius: 8 }}>
+        {scene.text}
+      </div>
+      <div style={{ marginTop: 16 }}>
+        {scene.choices.map((c) => (
+          <button key={c.tag} onClick={() => handleChoice(c.tag)} style={{ marginRight: 8 }}>
+            {c.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/scenes/__tests__/SceneView.test.tsx
+++ b/frontend/src/scenes/__tests__/SceneView.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SceneView from '../SceneView';
+
+describe('SceneView', () => {
+  it('shows start scene then next scene on choice', async () => {
+    const startScene = { sceneTag: 'intro_001', text: 'Start here', choices: [{ tag: '1', label: 'Go' }] };
+    const nextScene = { sceneTag: 'dark_forest', text: 'Dark path', choices: [] };
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce({ json: () => Promise.resolve(startScene) } as any)
+      .mockResolvedValueOnce({ json: () => Promise.resolve(nextScene) } as any);
+    (global as any).fetch = fetchMock;
+
+    const user = userEvent.setup();
+    render(<SceneView />);
+
+    expect(await screen.findByText('Start here')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Go' }));
+    expect(await screen.findByText('Dark path')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/backend/test_story_engine.py
+++ b/tests/backend/test_story_engine.py
@@ -1,0 +1,43 @@
+import json
+import importlib.util
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+BACKEND_DIR = ROOT_DIR / "backend"
+STATE_FILE = BACKEND_DIR / "player_state.json"
+
+
+def import_app():
+    spec = importlib.util.spec_from_file_location("main", BACKEND_DIR / "main.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.app
+
+
+def setup_function(_):
+    STATE_FILE.write_text("{}", encoding="utf-8")
+
+
+def test_start_and_choice():
+    client = TestClient(import_app())
+
+    r = client.post("/start", json={"soulSeedId": "abc"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["sceneTag"] == "intro_001"
+    assert "crossroad" in data["text"]
+    assert any(c["tag"] == "1" for c in data["choices"])
+
+    r2 = client.post(
+        "/choice",
+        json={"soulSeedId": "abc", "sceneTag": "intro_001", "choiceTag": "1"},
+    )
+    assert r2.status_code == 200
+    next_data = r2.json()
+    assert next_data["sceneTag"] == "dark_forest"
+    assert "dark forest" in next_data["text"].lower()
+
+    state = json.loads(STATE_FILE.read_text())
+    assert state["soulMap"]["abc"] == ["dark_forest"]
+


### PR DESCRIPTION
## Summary
- implement `/start` and `/choice` endpoints
- extend story with `intro_001`
- add React `SceneView` for running scenes
- wire scene route in `App`
- test story engine and scene view

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850933280f0832b846bf6da895462a1