### PR TITLE
feat: animated theme based on trust

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -151,3 +151,10 @@ def make_choice(req: ChoiceRequest) -> SceneResponse:
 
     return _scene_to_response(next_tag, story)
 
+
+@app.get("/trust")
+def get_trust(soulSeedId: str) -> dict:
+    state = load_json(STATE_FILE, {"trust": {}})
+    trust_map = state.get("trust", {})
+    return {"trust": float(trust_map.get(soulSeedId, 0))}
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "@types/react-router-dom": "^5.3.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^6.30.1"
+    "react-router-dom": "^6.30.1",
+    "framer-motion": "^11.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
@@ -35,6 +36,9 @@
     "ts-node": "^10.9.2",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.19"
   }
 }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/scenes/SceneView.tsx
+++ b/frontend/src/scenes/SceneView.tsx
@@ -1,11 +1,20 @@
 import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
 
 type Choice = { tag: string; label: string };
 type Scene = { sceneTag: string; text: string; choices: Choice[] };
 
 export default function SceneView() {
   const [scene, setScene] = useState<Scene | null>(null);
+  const [trust, setTrust] = useState(0);
   const soulSeedId = 'demo';
+
+  const fetchTrust = () => {
+    fetch(`/trust?soulSeedId=${soulSeedId}`)
+      .then((r) => r.json())
+      .then((d) => setTrust(Number(d.trust) || 0))
+      .catch(() => {});
+  };
 
   useEffect(() => {
     fetch('/start', {
@@ -14,7 +23,10 @@ export default function SceneView() {
       body: JSON.stringify({ soulSeedId }),
     })
       .then((r) => r.json())
-      .then(setScene)
+      .then((data) => {
+        setScene(data);
+        fetchTrust();
+      })
       .catch(() => {});
   }, []);
 
@@ -26,7 +38,10 @@ export default function SceneView() {
       body: JSON.stringify({ soulSeedId, sceneTag: scene.sceneTag, choiceTag }),
     })
       .then((r) => r.json())
-      .then(setScene)
+      .then((data) => {
+        setScene(data);
+        fetchTrust();
+      })
       .catch(() => {});
   };
 
@@ -34,11 +49,19 @@ export default function SceneView() {
     return <div>Loading...</div>;
   }
 
+  const bgClass = trust > 0 ? 'bg-meadow' : 'bg-forest';
+  const bgColor = trust > 0 ? '#ccff99' : '#006600';
+
   return (
     <div style={{ padding: 24, fontFamily: 'sans-serif' }}>
-      <div style={{ background: '#eee', padding: 12, borderRadius: 8 }}>
+      <motion.div
+        className={`${bgClass} p-3 rounded`}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1, backgroundColor: bgColor }}
+        transition={{ duration: 0.5 }}
+      >
         {scene.text}
-      </div>
+      </motion.div>
       <div style={{ marginTop: 16 }}>
         {scene.choices.map((c) => (
           <button key={c.tag} onClick={() => handleChoice(c.tag)} style={{ marginRight: 8 }}>

--- a/frontend/src/scenes/__tests__/SceneView.test.tsx
+++ b/frontend/src/scenes/__tests__/SceneView.test.tsx
@@ -6,9 +6,12 @@ describe('SceneView', () => {
   it('shows start scene then next scene on choice', async () => {
     const startScene = { sceneTag: 'intro_001', text: 'Start here', choices: [{ tag: '1', label: 'Go' }] };
     const nextScene = { sceneTag: 'dark_forest', text: 'Dark path', choices: [] };
-    const fetchMock = jest.fn()
+    const fetchMock = jest
+      .fn()
       .mockResolvedValueOnce({ json: () => Promise.resolve(startScene) } as any)
-      .mockResolvedValueOnce({ json: () => Promise.resolve(nextScene) } as any);
+      .mockResolvedValueOnce({ json: () => Promise.resolve({ trust: 0 }) } as any)
+      .mockResolvedValueOnce({ json: () => Promise.resolve(nextScene) } as any)
+      .mockResolvedValueOnce({ json: () => Promise.resolve({ trust: 0 }) } as any);
     (global as any).fetch = fetchMock;
 
     const user = userEvent.setup();
@@ -17,6 +20,20 @@ describe('SceneView', () => {
     expect(await screen.findByText('Start here')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Go' }));
     expect(await screen.findByText('Dark path')).toBeInTheDocument();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('applies forest theme when trust negative', async () => {
+    const startScene = { sceneTag: 'intro_001', text: 'Start here', choices: [] };
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ json: () => Promise.resolve(startScene) } as any)
+      .mockResolvedValueOnce({ json: () => Promise.resolve({ trust: -5 }) } as any);
+    (global as any).fetch = fetchMock;
+
+    render(<SceneView />);
+
+    const card = await screen.findByText('Start here');
+    expect(card).toHaveClass('bg-forest');
   });
 });

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,13 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        meadow: '#ccff99',
+        forest: '#006600',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/tests/backend/test_trust_endpoint.py
+++ b/tests/backend/test_trust_endpoint.py
@@ -1,0 +1,26 @@
+import json
+import importlib.util
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+BACKEND_FILE = ROOT / "backend" / "main.py"
+STATE_FILE = ROOT / "backend" / "player_state.json"
+
+def import_app():
+    spec = importlib.util.spec_from_file_location("main", BACKEND_FILE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.app
+
+
+def setup_function(_):
+    STATE_FILE.write_text(json.dumps({"trust": {"demo": -5}}), encoding="utf-8")
+
+
+def test_get_trust():
+    client = TestClient(import_app())
+    resp = client.get("/trust", params={"soulSeedId": "demo"})
+    assert resp.status_code == 200
+    assert resp.json()["trust"] == -5
+


### PR DESCRIPTION
## Summary
- style with TailwindCSS and Framer Motion
- color themes `meadow` and `forest`
- animate SceneView based on trust value
- fetch trust from new `/trust` backend route
- add tests for trust endpoint and theme behavior

## Testing
- `npm test` in `frontend`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68509666a7c0832b8f0edb354f822f9e