### PR TITLE
Implement avatar persistence context

### DIFF
--- a/frontend/src/AvatarContext.tsx
+++ b/frontend/src/AvatarContext.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+
+export type AvatarContextValue = {
+  avatarUrl: string | null;
+  setAvatarUrl: (url: string) => void;
+};
+
+const AvatarContext = createContext<AvatarContextValue | undefined>(undefined);
+
+export function AvatarProvider({ children }: { children: ReactNode }) {
+  const [avatarUrl, setAvatarUrlState] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('avatarUrl');
+    if (stored) {
+      setAvatarUrlState(stored);
+    }
+  }, []);
+
+  const setAvatarUrl = (url: string) => {
+    localStorage.setItem('avatarUrl', url);
+    setAvatarUrlState(url);
+  };
+
+  return (
+    <AvatarContext.Provider value={{ avatarUrl, setAvatarUrl }}>
+      {children}
+    </AvatarContext.Provider>
+  );
+}
+
+export function useAvatar() {
+  const ctx = useContext(AvatarContext);
+  if (ctx) {
+    return ctx;
+  }
+  const stored = localStorage.getItem('avatarUrl');
+  const setAvatarUrl = (url: string) => {
+    localStorage.setItem('avatarUrl', url);
+  };
+  return { avatarUrl: stored, setAvatarUrl };
+}
+
+export default AvatarContext;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { AvatarProvider } from "./AvatarContext";
 import "./index.css";     // leave even if index.css is empty
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <AvatarProvider>
+      <App />
+    </AvatarProvider>
   </React.StrictMode>
 );

--- a/frontend/src/scenes/AvatarCreate.tsx
+++ b/frontend/src/scenes/AvatarCreate.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useAvatar } from '../AvatarContext';
 import axios from 'axios';
 
 export default function AvatarCreate() {
@@ -8,6 +9,7 @@ export default function AvatarCreate() {
   const [file, setFile] = useState<File | null>(null);
   const [preview, setPreview] = useState('');
   const [profile, setProfile] = useState<Record<string, string> | null>(null);
+  const { setAvatarUrl } = useAvatar();
 
   const slugify = (value: string) =>
     value
@@ -37,6 +39,11 @@ export default function AvatarCreate() {
     };
     const res = await axios.post('/soulseed', body);
     setProfile(res.data);
+    const returnedUrl = (res.data && res.data.avatarReferenceUrl) || avatarUrl;
+    if (returnedUrl) {
+      localStorage.setItem('avatarUrl', returnedUrl);
+      setAvatarUrl(returnedUrl);
+    }
   };
 
   return (

--- a/frontend/src/scenes/SceneView.tsx
+++ b/frontend/src/scenes/SceneView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useAvatar } from '../AvatarContext';
 import { motion } from 'framer-motion';
 
 type Choice = { tag: string; label: string };
@@ -8,6 +9,7 @@ export default function SceneView() {
   const [scene, setScene] = useState<Scene | null>(null);
   const [trust, setTrust] = useState(0);
   const soulSeedId = 'demo';
+  const { avatarUrl } = useAvatar();
 
   const fetchTrust = () => {
     fetch(`/trust?soulSeedId=${soulSeedId}`)
@@ -54,6 +56,11 @@ export default function SceneView() {
 
   return (
     <div style={{ padding: 24, fontFamily: 'sans-serif' }}>
+      {avatarUrl && (
+        <div style={{ marginBottom: 8 }}>
+          <img src={avatarUrl} alt="Your avatar" style={{ maxWidth: 100, borderRadius: '50%' }} />
+        </div>
+      )}
       <motion.div
         key={scene.sceneTag}
         className={`${bgClass} p-3 rounded`}


### PR DESCRIPTION
## Summary
- store avatar reference in `localStorage` after creating soul seed
- add `AvatarContext` with provider and hook
- display saved avatar image in `SceneView`
- wrap app with `AvatarProvider`

## Testing
- `npm test --silent` in `frontend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850c6e7a970832b8b2381acf7b814cf