### PR TITLE
Add new scenes and editor endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, constr
 from pathlib import Path
 from fastapi.staticfiles import StaticFiles
@@ -12,6 +13,7 @@ DATA_FILE = Path(__file__).resolve().parent / "player_profile.json"
 UPLOADS_DIR = Path(__file__).resolve().parents[1] / "uploads"
 STORY_FILE = Path(__file__).resolve().parent / "story.json"
 STATE_FILE = Path(__file__).resolve().parent / "player_state.json"
+EDITOR_FILE = Path(__file__).resolve().parent / "editor.html"
 
 app.mount("/static", StaticFiles(directory=UPLOADS_DIR, check_dir=False), name="static")
 
@@ -157,4 +159,12 @@ def get_trust(soulSeedId: str) -> dict:
     state = load_json(STATE_FILE, {"trust": {}})
     trust_map = state.get("trust", {})
     return {"trust": float(trust_map.get(soulSeedId, 0))}
+
+
+@app.get("/editor", response_class=HTMLResponse)
+def story_editor() -> HTMLResponse:
+    """Serve a basic HTML page for editing the story JSON."""
+    if EDITOR_FILE.exists():
+        return HTMLResponse(EDITOR_FILE.read_text())
+    return HTMLResponse("<html><body><h1>Story Editor</h1></body></html>")
 

--- a/backend/story.json
+++ b/backend/story.json
@@ -2,8 +2,8 @@
   "intro_001": {
     "text": "You are standing at a crossroad. Where do you want to go?",
     "choices": {
-      "1": "dark_forest",
-      "2": "sunny_meadow"
+      "1": "mysterious_cave",
+      "2": "peaceful_river"
     }
   },
   "dark_forest": {
@@ -31,6 +31,16 @@
   },
   "lie_down": {
     "text": "You lie down in the meadow and fall into a deep, restful sleep. The End."
+  },
+  "peaceful_river": {
+    "text": "You follow the path to a peaceful river. The sound of running water calms your spirit. The End."
+  },
+  "mysterious_cave": {
+    "text": "You venture into a mysterious cave. The air is damp and echoes with distant sounds.",
+    "choices": {
+      "1": "investigate_noise",
+      "2": "run_away"
+    }
   },
   "secret_cave": {
     "text": "You discover a hidden cave glittering with ancient crystals. The air hums with power!"

--- a/tests/backend/test_story_engine.py
+++ b/tests/backend/test_story_engine.py
@@ -35,9 +35,9 @@ def test_start_and_choice():
     )
     assert r2.status_code == 200
     next_data = r2.json()
-    assert next_data["sceneTag"] == "dark_forest"
-    assert "dark forest" in next_data["text"].lower()
+    assert next_data["sceneTag"] == "mysterious_cave"
+    assert "mysterious cave" in next_data["text"].lower()
 
     state = json.loads(STATE_FILE.read_text())
-    assert state["soulMap"]["abc"] == ["dark_forest"]
+    assert state["soulMap"]["abc"] == ["mysterious_cave"]
 


### PR DESCRIPTION
## Summary
- extend story.json with peaceful_river and mysterious_cave scenes
- update intro choice routes
- stub a `/editor` endpoint returning static HTML
- adjust tests for new starting branch

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c71af204832bb27c9d9cbb3f47d1