### PR TITLE
Add backend and frontend tests

### DIFF
--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,115 @@
+import json
+import importlib.util
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+ROOT = Path(__file__).resolve().parents[2]
+APP_PATH = ROOT / "backend" / "main.py"
+PROFILE_FILE = ROOT / "backend" / "player_profile.json"
+STATE_FILE = ROOT / "backend" / "player_state.json"
+
+
+def import_app():
+    spec = importlib.util.spec_from_file_location("main", APP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.app
+
+
+@pytest.fixture(autouse=True)
+def clean_files():
+    PROFILE_FILE.write_text("{}", encoding="utf-8")
+    STATE_FILE.write_text("{}", encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_soulseed_creation():
+    app = import_app()
+    transport = ASGITransport(app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/soulseed",
+            json={"playerName": "Alice", "archetypePreset": "wizard"},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["playerId"] == "alice"
+    assert data["initSceneTag"] == "intro_001"
+    assert isinstance(data["soulSeedId"], str) and len(data["soulSeedId"]) == 12
+    profiles = json.loads(PROFILE_FILE.read_text())
+    assert data["playerId"] in profiles
+
+
+@pytest.mark.asyncio
+async def test_start_and_choice_flow():
+    app = import_app()
+    transport = ASGITransport(app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        start = await ac.post("/start", json={"soulSeedId": "abc"})
+        assert start.status_code == 200
+        assert start.json()["sceneTag"] == "intro_001"
+
+        choice = await ac.post(
+            "/choice",
+            json={"soulSeedId": "abc", "sceneTag": "intro_001", "choiceTag": "1"},
+        )
+    assert choice.status_code == 200
+    assert choice.json()["sceneTag"] == "dark_forest"
+    state = json.loads(STATE_FILE.read_text())
+    assert state["soulMap"]["abc"] == ["dark_forest"]
+
+
+@pytest.mark.asyncio
+async def test_choice_invalid_tag():
+    app = import_app()
+    transport = ASGITransport(app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        with pytest.raises(KeyError):
+            await ac.post(
+                "/choice",
+                json={
+                    "soulSeedId": "bad",
+                    "sceneTag": "intro_001",
+                    "choiceTag": "99",
+                },
+            )
+
+
+@pytest.mark.asyncio
+async def test_start_missing_soulseed():
+    app = import_app()
+    transport = ASGITransport(app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/start", json={})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_trust_endpoint():
+    STATE_FILE.write_text(json.dumps({"trust": {"demo": 5}}), encoding="utf-8")
+    app = import_app()
+    transport = ASGITransport(app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/trust", params={"soulSeedId": "demo"})
+    assert resp.status_code == 200
+    assert resp.json()["trust"] == 5.0
+
+
+@pytest.mark.asyncio
+async def test_trust_missing_soulseed():
+    app = import_app()
+    transport = ASGITransport(app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/trust")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_reset_missing_endpoint():
+    app = import_app()
+    transport = ASGITransport(app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/reset")
+    assert resp.status_code == 404

--- a/frontend/src/__tests__/AvatarCreate.test.tsx
+++ b/frontend/src/__tests__/AvatarCreate.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+import AvatarCreate from '../scenes/AvatarCreate';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+it('submits avatar form and shows profile', async () => {
+  mockedAxios.post.mockResolvedValueOnce({
+    data: { playerId: 'alice', soulSeedId: 'abc123def456', initSceneTag: 'intro_001' },
+  });
+
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter>
+      <AvatarCreate />
+    </MemoryRouter>
+  );
+
+  await user.type(screen.getByPlaceholderText('Your Name'), 'Alice');
+  await user.selectOptions(screen.getByRole('combobox'), 'Visionary Dreamer');
+  await user.click(screen.getByRole('button', { name: /confirm avatar/i }));
+
+  expect(mockedAxios.post).toHaveBeenCalledWith('/soulseed', {
+    playerName: 'Alice',
+    archetypePreset: 'Visionary Dreamer',
+    archetypeCustom: null,
+    avatarReferenceUrl: null,
+  });
+
+  expect(await screen.findByText(/Avatar Created!/)).toBeInTheDocument();
+});

--- a/frontend/src/__tests__/SceneView.test.tsx
+++ b/frontend/src/__tests__/SceneView.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import SceneView from '../scenes/SceneView';
+
+it('renders start scene with trust styling', async () => {
+  const startScene = { sceneTag: 'intro_001', text: 'Start here', choices: [{ tag: '1', label: 'Go' }] };
+  (global as any).fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ json: () => Promise.resolve(startScene) } as any)
+    .mockResolvedValueOnce({ json: () => Promise.resolve({ trust: 5 }) } as any);
+
+  render(<SceneView />);
+
+  const text = await screen.findByText('Start here');
+  expect(text).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Go' })).toBeInTheDocument();
+  expect(text).toHaveClass('bg-meadow');
+});

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 addopts = -q
-testpaths = tests
+testpaths =
+    tests
+    backend/tests


### PR DESCRIPTION
## Summary
- add async API tests for FastAPI app
- extend pytest config for new test location
- test AvatarCreate form and SceneView component

## Testing
- `pytest -q`
- `npx jest --runTestsByPath src/scenes/__tests__/Liminal.test.tsx src/scenes/__tests__/SceneView.test.tsx src/__tests__/AvatarCreate.test.tsx src/__tests__/SceneView.test.tsx --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850c727f4a4832b9d4ae2e8d57a257f