### PR TITLE
Set up CO01 orchestrator skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Contracts are **versioned**; breaking changes require bumping `_vX` suffix and u
 
 Codex automatically stubs missing upstream APIs; once a sprint lands, flip the feature flag in `codex/config.yaml`.
 
+### CO01 Orchestrator Quickstart
+Run:
+```bash
+python run_codex.py
+```
+Visit `http://localhost:9000/tasks` for task status.
+
+
 ---
 
 ## 🧪 Tests & CI

--- a/codex/agents.py
+++ b/codex/agents.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Agent role definitions and stubs for each sprint."""
+
+from typing import Any, Callable
+
+
+class Agent:
+    """Simple callable agent wrapper."""
+
+    def __init__(self, name: str, handler: Callable[[], Any]):
+        self.name = name
+        self.handler = handler
+
+    def run(self) -> Any:
+        return self.handler()
+
+
+# --- Sprint agent stubs -------------------------------------------------------
+
+def ritual_agent() -> str:
+    return "TR01 done"
+
+
+def avatar_agent() -> str:
+    return "AV01 done"
+
+
+def soulmap_agent() -> str:
+    return "SM01 done"
+
+
+def story_agent() -> str:
+    return "ST01 done"
+
+
+AGENTS: dict[str, Agent] = {
+    "TR01": Agent("Ritual", ritual_agent),
+    "AV01": Agent("Avatar", avatar_agent),
+    "SM01": Agent("SoulMap", soulmap_agent),
+    "ST01": Agent("Story", story_agent),
+}

--- a/codex/dashboard.py
+++ b/codex/dashboard.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""FastAPI dashboard exposing orchestrator status."""
+
+from fastapi import FastAPI
+
+from .orchestrator import Orchestrator
+
+app = FastAPI(title="Codex Orchestrator")
+orc = Orchestrator()
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    await orc.start([])
+
+
+@app.get("/tasks")
+async def list_tasks() -> dict:
+    return {
+        "queued": [t.sprint for t in orc.queue._queue._queue],
+        "active": {k: v.sprint for k, v in orc.active.items()},
+        "completed": [{"sprint": t.sprint, "status": t.status} for t in orc.queue.completed],
+    }

--- a/codex/orchestrator.py
+++ b/codex/orchestrator.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Central orchestrator for all sprint agents."""
+
+import asyncio
+from typing import Any, Dict
+
+from .agents import AGENTS
+from .task_queue import Task, TaskQueue
+from .validation import VALIDATORS
+
+
+class Orchestrator:
+    def __init__(self) -> None:
+        self.queue = TaskQueue()
+        self.active: Dict[int, Task] = {}
+
+    async def submit(self, sprint: str, payload: dict[str, Any] | None = None) -> None:
+        await self.queue.add(Task(sprint=sprint, payload=payload))
+
+    async def worker(self) -> None:
+        while True:
+            task = await self.queue.get()
+            self.active[id(task)] = task
+            agent = AGENTS.get(task.sprint)
+            if not agent:
+                task.log.append(f"unknown sprint {task.sprint}")
+                task.status = "error"
+            else:
+                try:
+                    task.status = "running"
+                    result = agent.run()
+                    task.result = result
+                    task.status = "done"
+                except Exception as exc:  # noqa: BLE001
+                    task.log.append(str(exc))
+                    task.status = "error"
+            self.active.pop(id(task), None)
+            await self.queue.mark_done(task)
+
+    async def start(self, initial: list[str]) -> None:
+        for sprint in initial:
+            await self.submit(sprint)
+        worker_task = asyncio.create_task(self.worker())
+        await self.queue._queue.join()
+        worker_task.cancel()

--- a/codex/task_queue.py
+++ b/codex/task_queue.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Simple in-memory task queue."""
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Task:
+    sprint: str
+    payload: dict[str, Any] | None = None
+    status: str = "pending"
+    result: Any | None = None
+    log: list[str] = field(default_factory=list)
+
+
+class TaskQueue:
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[Task] = asyncio.Queue()
+        self.completed: list[Task] = []
+
+    async def add(self, task: Task) -> None:
+        await self._queue.put(task)
+
+    async def get(self) -> Task:
+        task = await self._queue.get()
+        return task
+
+    async def mark_done(self, task: Task) -> None:
+        self.completed.append(task)
+        self._queue.task_done()

--- a/codex/validation.py
+++ b/codex/validation.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Placeholder validation helpers."""
+
+from hashlib import sha256
+from typing import Any
+
+
+def validate_pose(data: dict[str, Any]) -> bool:
+    return "pose" in data
+
+
+def validate_schema(data: dict[str, Any]) -> bool:
+    return "schema" in data
+
+
+def asset_hash(data: bytes) -> str:
+    return sha256(data).hexdigest()
+
+
+VALIDATORS = {
+    "pose": validate_pose,
+    "schema": validate_schema,
+}

--- a/run_codex.py
+++ b/run_codex.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import asyncio
+
+from codex.orchestrator import Orchestrator
+
+
+async def main() -> None:
+    orc = Orchestrator()
+    await orc.submit("TR01")
+    await orc.submit("AV01")
+    await orc.submit("SM01")
+    await orc.submit("ST01")
+    await orc.start([])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add new `codex` package with agents, task queue, orchestrator, validators and dashboard
- provide a `run_codex.py` helper
- document how to start the orchestrator

## Testing
- `pytest -q` *(fails: NameError in backend tests)*

------
https://chatgpt.com/codex/tasks/task_e_6854fffe06ac832bbd9357b65823858a